### PR TITLE
Fix Gii not found error when env is not set to dev

### DIFF
--- a/console/config/main.php
+++ b/console/config/main.php
@@ -9,11 +9,8 @@ $params = array_merge(
 return [
     'id' => 'app-console',
     'basePath' => dirname(__DIR__),
-    'bootstrap' => ['log', 'gii'],
+    'bootstrap' => ['log'],
     'controllerNamespace' => 'console\controllers',
-    'modules' => [
-        'gii' => 'yii\gii\Module',
-    ],
     'components' => [
         'log' => [
             'targets' => [

--- a/environments/dev/console/config/main-local.php
+++ b/environments/dev/console/config/main-local.php
@@ -1,3 +1,7 @@
 <?php
 return [
+    'bootstrap' => ['gii'],
+    'modules' => [
+        'gii' => 'yii\gii\Module',
+    ],
 ];


### PR DESCRIPTION
Fixed an error when using console in a non dev environment that "Gii Module not found"
